### PR TITLE
Fixed code splitting js issue by removing all <style> tags.

### DIFF
--- a/resources/css/components/editor.css
+++ b/resources/css/components/editor.css
@@ -1,0 +1,8 @@
+.trix-button-row {
+    display: flex;
+    flex-wrap: wrap !important;
+}
+
+progress.attachment__progress {
+    display: none;
+}

--- a/resources/css/components/main.css
+++ b/resources/css/components/main.css
@@ -5,3 +5,6 @@
 @import './posts.css';
 @import './social.css';
 @import './backgrounds.css';
+@import './editor.css';
+@import './modals.css';
+@import './search.css';

--- a/resources/css/components/modals.css
+++ b/resources/css/components/modals.css
@@ -1,0 +1,5 @@
+.v--modal-overlay[data-modal="modal-name"] .v--modal-box.v--modal {
+    opacity: 1;
+    overflow: visible;
+    top: 178px !important;
+}

--- a/resources/css/components/search.css
+++ b/resources/css/components/search.css
@@ -1,0 +1,7 @@
+.search-component {
+    z-index: 100;
+}
+a.hit em {
+    color: #4299E1;
+    font-weight: 600;
+}

--- a/resources/js/Pages/Posts/Create.vue
+++ b/resources/js/Pages/Posts/Create.vue
@@ -59,13 +59,3 @@ export default {
     },
 }
 </script>
-
-<style>
-.trix-button-row {
-    display: flex;
-    flex-wrap: wrap !important;
-}
-progress.attachment__progress {
-    display: none;
-}
-</style>

--- a/resources/js/Pages/Posts/Index.vue
+++ b/resources/js/Pages/Posts/Index.vue
@@ -35,7 +35,3 @@ export default {
     },
 }
 </script>
-
-<style>
-
-</style>

--- a/resources/js/Pages/Posts/Show.vue
+++ b/resources/js/Pages/Posts/Show.vue
@@ -24,7 +24,3 @@ export default {
     },
 }
 </script>
-
-<style>
-
-</style>

--- a/resources/js/Shared/BlankLayout.vue
+++ b/resources/js/Shared/BlankLayout.vue
@@ -12,7 +12,3 @@ export default {
     components: { FlashMessage },
 }
 </script>
-
-<style>
-
-</style>

--- a/resources/js/Shared/FlashMessage.vue
+++ b/resources/js/Shared/FlashMessage.vue
@@ -51,7 +51,3 @@ export default {
     },
 }
 </script>
-
-<style>
-
-</style>

--- a/resources/js/Shared/Modal.vue
+++ b/resources/js/Shared/Modal.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <modal-component name="modal-name" width="80%" :maxWidth="1000" :adaptive="true" :delay="250" height="auto" class="text-center center" @before-open="beforeOpen($event)" />
+        <modal-component name="modal-name" width="80%" :max-width="1000" :adaptive="true" :delay="250" height="auto" class="text-center center" @before-open="beforeOpen($event)" />
     </div>
 </template>
 
@@ -17,11 +17,3 @@
         }
     }
 </script>
-
-<style>
-    .v--modal-overlay[data-modal="modal-name"] .v--modal-box.v--modal {
-        opacity: 1;
-        overflow: visible;
-        top: 178px !important;
-    }
-</style>

--- a/resources/js/Shared/SearchBox.vue
+++ b/resources/js/Shared/SearchBox.vue
@@ -47,13 +47,3 @@ export default {
     },
 };
 </script>
-
-<style>
-.search-component {
-    z-index: 100;
-}
-a.hit em {
-    color: #4299E1;
-    font-weight: 600;
-}
-</style>

--- a/resources/js/Shared/SiteFooter.vue
+++ b/resources/js/Shared/SiteFooter.vue
@@ -60,7 +60,3 @@ export default {
 
 }
 </script>
-
-<style>
-
-</style>

--- a/resources/js/Shared/SocialLinks.vue
+++ b/resources/js/Shared/SocialLinks.vue
@@ -24,7 +24,3 @@ export default {
 
 }
 </script>
-
-<style>
-
-</style>

--- a/resources/js/lib/vue/index.js
+++ b/resources/js/lib/vue/index.js
@@ -55,15 +55,13 @@ if (process.env.MIX_APP_ENV === 'production') {
 }
 
 let app = document.getElementById('app');
-const files = require.context('../../', true, /\.vue$/i);
 
 new Vue({
     data: { store },
     render: h => h(Inertia, {
         props: {
             initialPage: JSON.parse(app.dataset.page),
-            resolveComponent: page => files(`./Pages/${page}.vue`).default,
-            // resolveComponent: name => import (`@/Pages/${name}`).then(module => module.default),
+            resolveComponent: name => import (`@/Pages/${name}`).then(module => module.default),
         },
     }),
 }).$mount(app)


### PR DESCRIPTION
- Fixed the code-splitting error "property 'call' of undefined", by removing all <style> tags inside single file vue components. Evidently this is a common error in webpack 4 with many different workarounds. This worked for me.