### PR TITLE
Redo about page. Do code splitting except on posts/create.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.enable": true
+}

--- a/resources/css/components/posts.css
+++ b/resources/css/components/posts.css
@@ -1,5 +1,5 @@
 /* purgecss start ignore */
-.trix-content h1, h2 {
+.trix-content h1, .trix-content h2 {
     @apply .font-medium .tracking-wide .text-2xl .text-blue-900 .my-4 !important;
 }
 .trix-content, .trix-content p, .trix-content ol > li {
@@ -43,5 +43,9 @@
     white-space: pre !important;
     overflow-x: auto !important;
     background: none !important;
+}
+
+.post-container:last-child {
+    border-bottom: none;
 }
 /* purgecss end ignore */

--- a/resources/js/Pages/About/Index.vue
+++ b/resources/js/Pages/About/Index.vue
@@ -1,18 +1,29 @@
 <template>
     <layout title="About Me">
-        <h1 class="w-2/3 uppercase text-3xl font-medium text-blue-900 border-b border-gray-600 pb-4 pt-4 mb-8">
-            About Me
+        <h1 class="w-2/3 uppercase text-3xl font-medium text-blue-900 pb-4 pt-4 mb-8">
+            A little about me
         </h1>
-        <p class="text-xl md:text-2xl text-blue-800 font-normal mb-4 leading-normal tracking-normal">
-            I began tinkering in web development about 15 years ago when I co-developed a client information system for a non-profit organization. Basically, the company wanted to move from a paper system to a web-accessible database-backed application. At the time, I had no experience in web development. No HTML, CSS, PHP, javascript... nothing. Fortunately, we knew that one of our clients had some experience in creating websites, so he spearheaded the project for us. Unfortunately, his experience was with Coldfusion. I spent the better part of 5 years, debugging, maintaining and adding features to a client information system written for the web in Coldfusion. Whatever your opinion of Coldfusion, it wasn't a pleasant experience, especially for a beginner.
-        </p>
-        <p class="text-xl md:text-2xl text-blue-800 font-normal mb-4 leading-normal tracking-normal">
-            It wasn't until about 5 years later that my interest was piqued again. This time with Ruby on Rails. I dabbled for a while and eventually discovered Laravel. I dove head first into Laravel, and I've learned a lot over the past couple of years. Now, I find myself backtracking and learning the fundamentals of web development and PHP, which I missed trying to find a shortcut to success in programming.
-        </p>
-        <p class="text-xl md:text-2xl text-blue-800 font-normal mb-4 leading-normal tracking-normal">
-            I've started this blog to track my experiences and to have a place to log what I'm learning. So this is more of a tool for me than anything else. However, maybe I'll write something that can be useful to others. Either way, I'm excited about what is to come.
-        </p>
-        <p class="text-xl md:text-2xl text-blue-800 font-normal mb-4 leading-normal tracking-normal">CRS</p>
+        <div class="w-full md:w-1/2">
+            <div class="flex flex-col justify-between">
+                <div class="flex mb-4 items-center">
+                    <h2 class="text-xl text-blue-900 mr-2 uppercase">Years in web development:</h2>
+                    <span class="text-lg text-blue-600">14</span>
+                </div>
+                <div class="flex mb-4 items-center">
+                    <h2 class="text-xl text-blue-900 mr-2 uppercase">Started with:</h2>
+                    <span class="text-lg text-blue-600">Coldfusion</span>
+                </div>
+                <div class="flex mb-8 items-center">
+                    <h2 class="text-xl text-blue-900 mr-2 uppercase">Current:</h2>
+                    <span class="text-lg text-blue-600">PHP(Laravel), Javascript(Vue), Firebase</span>
+                </div>
+                <div class="flex mb-4 items-center">
+                    <span class="text-lg text-blue-900 leading-loose">
+                        I've started this blog to track my experiences and to have a place to log what I'm learning. So this is more of a tool for me than anything else. However, maybe I'll write something that can be useful to others. Either way, I'm excited about what is to come.
+                    </span>
+                </div>
+            </div>
+        </div>
     </layout>
 </template>
 

--- a/resources/js/Pages/Home/Index.vue
+++ b/resources/js/Pages/Home/Index.vue
@@ -4,7 +4,7 @@
             Latest Posts
         </h1>
         <div v-if="posts.length > 0" class="w-full md:w-1/2">
-            <div v-for="post in posts" :key="post.id" class="py-8 border-b-4 border-gray-300">
+            <div v-for="post in posts" :key="post.id" class="post-container py-8 border-b-4 border-gray-300">
                 <h2 class="font-medium text-2xl mb-2 md:text-3xl tracking-wide">
                     <inertia-link :href="route('post.show', post.slug)" class="text-blue-900 hover:text-blue-500 no-underline">{{ post.title }}</inertia-link>
                 </h2>

--- a/resources/js/Shared/Layout.vue
+++ b/resources/js/Shared/Layout.vue
@@ -3,7 +3,7 @@
         <portal-target name="dropdown" slim />
         <flash-message />
         <div class="flex flex-col">
-            <div class="min-h-screen flex flex-col" @click="hideDropdownMenus">
+            <div class="flex flex-col" @click="hideDropdownMenus">
                 <div class="flex flex-wrap">
                     <div class="bg-blue-900 flex-no-shrink w-full px-4 py-8 md:p-12 flex justify-between items-center">
                         <inertia-link class="mt-1" :href="route('home')">

--- a/resources/js/lib/vue/index.js
+++ b/resources/js/lib/vue/index.js
@@ -55,15 +55,20 @@ if (process.env.MIX_APP_ENV === 'production') {
 }
 
 let app = document.getElementById('app');
-const files = require.context('../../', true, /\.vue$/i);
+
+const pages = {
+    'Posts/Create': require('../../Pages/Posts/Create').default,
+  }
 
 new Vue({
     data: { store },
     render: h => h(Inertia, {
         props: {
             initialPage: JSON.parse(app.dataset.page),
-            resolveComponent: page => files(`./Pages/${page}.vue`).default,
-            // resolveComponent: name => import (`@/Pages/${name}`).then(module => module.default),
+            // resolveComponent: page => files(`./Pages/${page}.vue`).default,
+            resolveComponent: name => {
+                return name !== 'Posts/Create' ? import (`@/Pages/${name}`).then(module => module.default) : pages[name];
+            },
         },
     }),
 }).$mount(app)

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="h-full bg-gray-200">
+<html class="bg-gray-200">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">


### PR DESCRIPTION
- Redo about page. Do code splitting except on posts/create.
    - Make About page less verbose.
    - Remove Posts/Create from code-splitting since it was the only page causing problems (due to trix component)